### PR TITLE
refactor(search): fuzzySearchFilters with variable dbfields

### DIFF
--- a/src/lib/server/db/employee.ts
+++ b/src/lib/server/db/employee.ts
@@ -70,11 +70,11 @@ export async function getEmployees(
 				or(
 					...(nonEmptySearchQuery
 						? [
-								...fuzzySearchFilters(employee.email, nonEmptySearchQuery, 1, true),
-								...fuzzySearchFilters(employee.fname, nonEmptySearchQuery, 2),
-								...fuzzySearchFilters(employee.lname, nonEmptySearchQuery, 2),
-								...fuzzyConcatSearchFilters(employee.fname, employee.lname, nonEmptySearchQuery, 3),
-								...fuzzyConcatSearchFilters(employee.lname, employee.fname, nonEmptySearchQuery, 3)
+								...fuzzySearchFilters(employee.email, nonEmptySearchQuery, {substr: true}),
+								...fuzzySearchFilters(employee.fname, nonEmptySearchQuery, {distance: 2}),
+								...fuzzySearchFilters(employee.lname, nonEmptySearchQuery, {distance: 2}),
+								...fuzzyConcatSearchFilters(employee.fname, employee.lname, nonEmptySearchQuery, {distance: 3}),
+								...fuzzyConcatSearchFilters(employee.lname, employee.fname, nonEmptySearchQuery, {distance: 3})
 							]
 						: [])
 				)

--- a/src/lib/server/db/employee.ts
+++ b/src/lib/server/db/employee.ts
@@ -1,7 +1,7 @@
 import { or, eq, sql, and } from 'drizzle-orm';
 import { employee, employeeEntry, employeeExit } from './schema/employee';
 import { StateInside, StateOutside, type State } from '$lib/types/state';
-import { fuzzyConcatSearchFilters, fuzzySearchFilters } from './fuzzysearch';
+import { fuzzySearchFilters } from './fuzzysearch';
 import { isInside } from '../isInside';
 import { DB as db } from './connect';
 import { capitalizeString, sanitizeString } from '$lib/utils/sanitize';
@@ -70,11 +70,11 @@ export async function getEmployees(
 				or(
 					...(nonEmptySearchQuery
 						? [
-								...fuzzySearchFilters(employee.email, nonEmptySearchQuery, {substr: true}),
-								...fuzzySearchFilters(employee.fname, nonEmptySearchQuery, {distance: 2}),
-								...fuzzySearchFilters(employee.lname, nonEmptySearchQuery, {distance: 2}),
-								...fuzzyConcatSearchFilters(employee.fname, employee.lname, nonEmptySearchQuery, {distance: 3}),
-								...fuzzyConcatSearchFilters(employee.lname, employee.fname, nonEmptySearchQuery, {distance: 3})
+								...fuzzySearchFilters([employee.email], nonEmptySearchQuery, { substr: true }),
+								...fuzzySearchFilters([employee.fname], nonEmptySearchQuery, { distance: 2 }),
+								...fuzzySearchFilters([employee.lname], nonEmptySearchQuery, { distance: 2 }),
+								...fuzzySearchFilters([employee.fname, employee.lname], nonEmptySearchQuery, { distance: 3 }),
+								...fuzzySearchFilters([employee.lname, employee.fname], nonEmptySearchQuery, { distance: 3 })
 							]
 						: [])
 				)

--- a/src/lib/server/db/employee.ts
+++ b/src/lib/server/db/employee.ts
@@ -70,7 +70,7 @@ export async function getEmployees(
 				or(
 					...(nonEmptySearchQuery
 						? [
-								...fuzzySearchFilters([employee.email], nonEmptySearchQuery, { substr: true }),
+								...fuzzySearchFilters([employee.email], nonEmptySearchQuery),
 								...fuzzySearchFilters([employee.fname], nonEmptySearchQuery, { distance: 2 }),
 								...fuzzySearchFilters([employee.lname], nonEmptySearchQuery, { distance: 2 }),
 								...fuzzySearchFilters([employee.fname, employee.lname], nonEmptySearchQuery, { distance: 3 }),

--- a/src/lib/server/db/fuzzysearch.ts
+++ b/src/lib/server/db/fuzzysearch.ts
@@ -20,19 +20,26 @@ export function fuzzySearchFilters(
 		throw new Error('Invalid searchQuery');
 	}
 
-	if (opts.substr === null) throw new Error('Invalid substr');
-	if (opts.distance === null || (opts.distance != undefined && opts.distance <= 0))
-		throw new Error('Invalid distance');
+	// Assert substr option is valid
+	if (opts.substr === null) {
+		throw new Error('Invalid substr option');
+	}
+
+	// Assert distance option is valid
+	if (opts.distance === null || (opts.distance !== undefined && opts.distance <= 0)) {
+		throw new Error('Invalid distance option');
+	}
 
 	const concatQuery = dbFields
 		.map((field) => sql`${field}`)
 		.reduce((prev, curr) => sql`${prev} || ' ' || ${curr}`);
 
 	// @ts-expect-error because there is no typedef for sql as first param in ilike function
-	const ilikeFilter = [ilike(concatQuery, `${opts.substr ? '%' : ''}${searchQuery}%`)];
-	const levenshteinFilter = opts.distance !== undefined
-		? [sql`LEVENSHTEIN(LOWER(${concatQuery}), ${searchQuery}) <= ${opts.distance}`]
-		: [];
+	const ilikeFilter = ilike(concatQuery, `${opts.substr ? '%' : ''}${searchQuery}%`);
+	const levenshteinFilter =
+		opts.distance !== undefined
+			? [sql`LEVENSHTEIN(LOWER(${concatQuery}), ${searchQuery}) <= ${opts.distance}`]
+			: [];
 
-	return [...ilikeFilter, ...levenshteinFilter];
+	return [ilikeFilter, ...levenshteinFilter];
 }

--- a/src/lib/server/db/fuzzysearch.ts
+++ b/src/lib/server/db/fuzzysearch.ts
@@ -12,7 +12,7 @@ export function fuzzySearchFilters(
 ): SQL[] {
 	// Assert dbFields are valid
 	if (dbFields === null || dbFields === undefined || dbFields.length === 0) {
-		throw new Error('Invalid dbField');
+		throw new Error('Invalid dbFields');
 	}
 
 	// Assert searchQuery is valid
@@ -20,13 +20,17 @@ export function fuzzySearchFilters(
 		throw new Error('Invalid searchQuery');
 	}
 
+	if (opts.substr === null) throw new Error('Invalid substr');
+	if (opts.distance === null || (opts.distance != undefined && opts.distance <= 0))
+		throw new Error('Invalid distance');
+
 	const concatQuery = dbFields
 		.map((field) => sql`${field}`)
 		.reduce((prev, curr) => sql`${prev} || ' ' || ${curr}`);
 
 	// @ts-expect-error because there is no typedef for sql as first param in ilike function
 	const ilikeFilter = [ilike(concatQuery, `${opts.substr ? '%' : ''}${searchQuery}%`)];
-	const levenshteinFilter = opts.distance
+	const levenshteinFilter = opts.distance !== undefined
 		? [sql`LEVENSHTEIN(LOWER(${concatQuery}), ${searchQuery}) <= ${opts.distance}`]
 		: [];
 

--- a/src/lib/server/db/fuzzysearch.ts
+++ b/src/lib/server/db/fuzzysearch.ts
@@ -1,17 +1,17 @@
 import { sql, ilike, type Column, type SQL } from 'drizzle-orm';
 
 type FuzzySearchFiltersOptions = {
-	distance?: number,
-	substr?: boolean
+	distance?: number;
+	substr?: boolean;
 };
 
 export function fuzzySearchFilters(
-	dbField: Column,
+	dbFields: Column[],
 	searchQuery: string,
 	opts: FuzzySearchFiltersOptions = {}
 ): SQL[] {
-	// Assert dbField is valid
-	if (dbField === null || dbField === undefined) {
+	// Assert dbFields are valid
+	if (dbFields === null || dbFields === undefined || dbFields.length === 0) {
 		throw new Error('Invalid dbField');
 	}
 
@@ -20,40 +20,15 @@ export function fuzzySearchFilters(
 		throw new Error('Invalid searchQuery');
 	}
 
-	const ilikeFilter = [ilike(dbField, `${opts.substr ? '%' : ''}${searchQuery}%`)];
-	const levenshteinFilter = opts.distance ? [sql`LEVENSHTEIN(LOWER(${dbField}), ${searchQuery}) <= ${opts.distance}`,] : [];
-	return [
-		...ilikeFilter,
-		...levenshteinFilter
-	];
-}
-
-export function fuzzyConcatSearchFilters(
-	dbField1: Column,
-	dbField2: Column,
-	searchQuery: string,
-	opts: FuzzySearchFiltersOptions = {}
-): SQL[] {
-	// Assert dbField1 is valid
-	if (dbField1 === null || dbField1 === undefined) {
-		throw new Error('Invalid dbField1');
-	}
-
-	// Assert dbField2 is valid
-	if (dbField2 === null || dbField2 === undefined) {
-		throw new Error('Invalid dbField2');
-	}
-
-	// Assert searchQuery is valid
-	if (searchQuery === null || searchQuery === undefined || searchQuery === '') {
-		throw new Error('Invalid searchQuery');
-	}
+	const concatQuery = dbFields
+		.map((field) => sql`${field}`)
+		.reduce((prev, curr) => sql`${prev} || ' ' || ${curr}`);
 
 	// @ts-expect-error because there is no typedef for sql as first param in ilike function
-	const ilikeFilter = [ilike(sql`${dbField1} || ' ' || ${dbField2}`, `${opts.substr ? '%' : ''}${searchQuery}%`)];
-	const levenshteinFilter = opts.distance ? [sql`LEVENSHTEIN(LOWER(${dbField1}) || ' ' || LOWER(${dbField2}), ${searchQuery}) <= ${opts.distance}`] : [];
-	return [
-		...ilikeFilter,
-		...levenshteinFilter
-	];
+	const ilikeFilter = [ilike(concatQuery, `${opts.substr ? '%' : ''}${searchQuery}%`)];
+	const levenshteinFilter = opts.distance
+		? [sql`LEVENSHTEIN(LOWER(${concatQuery}), ${searchQuery}) <= ${opts.distance}`]
+		: [];
+
+	return [...ilikeFilter, ...levenshteinFilter];
 }

--- a/src/lib/server/db/student.ts
+++ b/src/lib/server/db/student.ts
@@ -1,7 +1,7 @@
 import { or, eq, sql, and } from 'drizzle-orm';
 import { student, studentEntry, studentExit } from './schema/student';
 import { StateInside, StateOutside, type State } from '$lib/types/state';
-import { fuzzyConcatSearchFilters, fuzzySearchFilters } from './fuzzysearch';
+import { fuzzySearchFilters } from './fuzzysearch';
 import { isInside } from '../isInside';
 import { DB as db } from './connect';
 import { capitalizeString, sanitizeString } from '$lib/utils/sanitize';
@@ -70,11 +70,11 @@ export async function getStudents(
 				or(
 					...(nonEmptySearchQuery
 						? [
-								...fuzzySearchFilters(student.index, nonEmptySearchQuery, {substr: true}),
-								...fuzzySearchFilters(student.fname, nonEmptySearchQuery, {distance: 2}),
-								...fuzzySearchFilters(student.lname, nonEmptySearchQuery, {distance: 2}),
-								...fuzzyConcatSearchFilters(student.fname, student.lname, nonEmptySearchQuery, {distance: 3}),
-								...fuzzyConcatSearchFilters(student.lname, student.fname, nonEmptySearchQuery, {distance: 3})
+								...fuzzySearchFilters([student.index], nonEmptySearchQuery, { substr: true }),
+								...fuzzySearchFilters([student.fname], nonEmptySearchQuery, { distance: 2 }),
+								...fuzzySearchFilters([student.lname], nonEmptySearchQuery, { distance: 2 }),
+								...fuzzySearchFilters([student.fname, student.lname], nonEmptySearchQuery, { distance: 3 }),
+								...fuzzySearchFilters([student.lname, student.fname], nonEmptySearchQuery, { distance: 3 }),
 							]
 						: [])
 				)

--- a/src/lib/server/db/student.ts
+++ b/src/lib/server/db/student.ts
@@ -70,7 +70,7 @@ export async function getStudents(
 				or(
 					...(nonEmptySearchQuery
 						? [
-								...fuzzySearchFilters([student.index], nonEmptySearchQuery, { substr: true }),
+								...fuzzySearchFilters([student.index], nonEmptySearchQuery),
 								...fuzzySearchFilters([student.fname], nonEmptySearchQuery, { distance: 2 }),
 								...fuzzySearchFilters([student.lname], nonEmptySearchQuery, { distance: 2 }),
 								...fuzzySearchFilters([student.fname, student.lname], nonEmptySearchQuery, { distance: 3 }),

--- a/src/lib/server/db/student.ts
+++ b/src/lib/server/db/student.ts
@@ -70,11 +70,11 @@ export async function getStudents(
 				or(
 					...(nonEmptySearchQuery
 						? [
-								...fuzzySearchFilters(student.index, nonEmptySearchQuery, 1, true),
-								...fuzzySearchFilters(student.fname, nonEmptySearchQuery, 2),
-								...fuzzySearchFilters(student.lname, nonEmptySearchQuery, 2),
-								...fuzzyConcatSearchFilters(student.fname, student.lname, nonEmptySearchQuery, 3),
-								...fuzzyConcatSearchFilters(student.lname, student.fname, nonEmptySearchQuery, 3)
+								...fuzzySearchFilters(student.index, nonEmptySearchQuery, {substr: true}),
+								...fuzzySearchFilters(student.fname, nonEmptySearchQuery, {distance: 2}),
+								...fuzzySearchFilters(student.lname, nonEmptySearchQuery, {distance: 2}),
+								...fuzzyConcatSearchFilters(student.fname, student.lname, nonEmptySearchQuery, {distance: 3}),
+								...fuzzyConcatSearchFilters(student.lname, student.fname, nonEmptySearchQuery, {distance: 3})
 							]
 						: [])
 				)


### PR DESCRIPTION
- Add search options as type
- Make search options optional
- Merge `fuzzySearchFilters` and `fuzzySearchConcatFilters` functions into one
- Add support for infinitely many fields for fuzzy searching